### PR TITLE
Add libreadline-dev to list of dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ install the dependencies. These are the names of the Debian packages:
   - lua-posix
   - ninja-build
   - libz80ex-dev
+  - libreadline-dev
 
 You _also_ need to install [the Amsterdam Compiler
 Kit](https://github.com/davidgiven/ack), which is used as the C compiler


### PR DESCRIPTION
make will fail at 70/90 after step 69/90 fails due to missing readline.h :

```
[69/90] gcc -c -o .obj/utils/emu/emu/main/emulator/emulator.o utils/emu/emulator.c -I.obj/utils/emu/biosbdos_cim_h -g -Og -Iutils/emu
FAILED: .obj/utils/emu/emu/main/emulator/emulator.o
gcc -c -o .obj/utils/emu/emu/main/emulator/emulator.o utils/emu/emulator.c -I.obj/utils/emu/biosbdos_cim_h -g -Og -Iutils/emu
utils/emu/emulator.c:6:10: fatal error: readline/readline.h: No such file or directory
 #include <readline/readline.h>
          ^~~~~~~~~~~~~~~~~~~~~
compilation terminated.
[70/90] gcc -c -o .obj/utils/emu/emu/main/biosbdos/biosbdos.o utils/emu/biosbdos.c -I.obj/utils/emu/biosbdos_cim_h -g -Og -Iutils/emu
utils/emu/biosbdos.c: In function ‘bios_getchar’:
utils/emu/biosbdos.c:201:2: warning: ignoring return value of ‘read’, declared with attribute warn_unused_result [-Wunused-result]
  (void) read(0, &c, 1);
  ^~~~~~~~~~~~~~~~~~~~~
utils/emu/biosbdos.c: In function ‘bdos_putchar’:
utils/emu/biosbdos.c:239:2: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
  (void) write(1, &c, 1);
  ^~~~~~~~~~~~~~~~~~~~~~
utils/emu/biosbdos.c: In function ‘bdos_printstring’:
utils/emu/biosbdos.c:263:3: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
   (void) write(1, &c, 1);
   ^~~~~~~~~~~~~~~~~~~~~~
utils/emu/biosbdos.c: In function ‘bios_warmboot’:
utils/emu/biosbdos.c:124:9: warning: ignoring return value of ‘read’, declared with attribute warn_unused_result [-Wunused-result]
         read(fd, &ram[0x0100], FBASE);
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
utils/emu/biosbdos.c: In function ‘bios_putchar’:
utils/emu/biosbdos.c:210:2: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
  (void) write(1, &c, 1);
  ^~~~~~~~~~~~~~~~~~~~~~
ninja: build stopped: subcommand failed.
Makefile:5: recipe for target 'all' failed
```