### PR TITLE
More Z8E fixes.

### DIFF
--- a/third_party/z8e/nc200/config.inc
+++ b/third_party/z8e/nc200/config.inc
@@ -2,4 +2,5 @@ z180	equ	false
 conterm	equ	adm3a
 auxterm	equ	none
 CPM3	equ	false
+SCRHT   equ 18
 

--- a/third_party/z8e/src/z8e.z80
+++ b/third_party/z8e/src/z8e.z80
@@ -456,7 +456,7 @@ getSCB	equ	49
 
 	export	height
 ;height:
-	defb	24		;Default (patchable) Screen height (in lines).
+	defb	SCRHT           ;Default (patchable) Screen height (in lines).
 				;(Don't bother patching if running CP/M Plus
 				; because Z8E will get the screen height from
 				; the SCB.)


### PR DESCRIPTION
This one allows the screen height to be specified in the build-time config file.