### PR TITLE
Better NC200 booting and PCMCIA support

### DIFF
--- a/arch/nc200/README.md
+++ b/arch/nc200/README.md
@@ -14,9 +14,10 @@ seamlessly run programs from disk if you use the right keyboard combination.
 What you get with this port:
 
 - standard PC 720kB floppy disks (with the CP/M file system, of course, but
-they're writeable from ordinary PC drives)
+  they're writeable from ordinary PC drives)
 - support for a hard drive of up to 32MB on a Compact Flash card (note: not
-SRAM)
+  SRAM)
+- CCP and BDOS cached in RAM for instant warm reboots
 - most of an ADM-3a / Kaypro II terminal emulator supporting 80x18 text
 - a gigantic 60kB TPA
 - an interrupt-driven keyboard
@@ -56,16 +57,18 @@ yet).
 
 To replace the BDOS:
 
-- create a standard 3.5kB BDOS image assembled at 0xf000.
+- create a standard 3.5kB BDOS image assembled at 0xef00.
 - do `dd if=my-custom-bdos.bin of=/dev/fd0 bs=1 seek=11264`
 
 To replace the CCP:
 
-- create a standard 2kB CCP image assembled at 0xe800.
+- create a standard 2kB CCP image assembled at 0xe700.
 - do `dd if=my-custom-ccp.bin of=/dev/fd0 bs=1 seek=9216`
 
-Then, inserting the disk into the NC200 and warm starting CP/M will load your
-new BDOS and CCP. (You don't even have to turn it off.)
+Then, inserting the disk into the NC200 and resetting the machine will start
+CP/M with load your new BDOS and CCP. Note that it is necessary to do a full
+reset to ensure that the new BDOS and CCP get loaded into the cache; a simple
+warm start isn't sufficient.
 
 
 Using a hard drive
@@ -98,6 +101,11 @@ will destroy any data on your card.
 Sadly, the NC200 is unable to boot from an ATA card, so you'll still need a
 floppy disk in the drive to start cpmish; but once booted, your files will be
 available on drive B.
+
+A tool FLIPDISK is available which will swap drives A: and B: in the BIOS. So,
+if you have a PCMCIA flash card, you can boot from floppy, run FLIPDISK, and
+then run everything from flash. This drastically speeds up everything,
+especially submit files, which use a temporary file on drive A:.
 
 If you have a CF card reader for a modern machine, the diskdefs file in the
 cpmish root should allow access to files on the card:

--- a/arch/nc200/README.md
+++ b/arch/nc200/README.md
@@ -121,9 +121,9 @@ The Supervisor is 8kB long and shares a 16kB bank with the video memory.
 However, it's only mapped in when it's actually doing something, so user code
 will never know it exists.
 
-Given that four banks provide the 64kB of CP/M userspace, and one bank
-contains the Supervisor, this leaves three banks spare; these are currently
-unused.
+Of the eight memory banks, four provide the 64kB of CP/M userspace, one
+contains the Supervisor and video memory, and one if used to cache the BDOS and
+CCP; the other two are currently unused.
 
 The terminal emulator is ADM-3a with some Kaypro II extensions, using a
 custom (drawn by me!) 6x7 font to allow 80x18 characters of text. This

--- a/arch/nc200/bios.z80
+++ b/arch/nc200/bios.z80
@@ -5,8 +5,8 @@
     maclib cpm
     maclib supervisor
     maclib nc200
+	maclib addresses
 
-    extern CBASE
     extern SCONIN
     extern SCONOUT
     extern SCONST
@@ -22,7 +22,7 @@
     extern SYSSTK
 
     cseg
-label BBASE
+	; BBASE is here
 
 ; BIOS jump table.
 

--- a/arch/nc200/bios.z80
+++ b/arch/nc200/bios.z80
@@ -61,6 +61,9 @@ label LISTST
 label SECTRAN
     jp SECTRANE
 
+; User configuration: set this to 1 to swap drives A/B (useful for HDD systems).
+driveswap: db 0
+
 ; BIOS interrupt handler. This is only invoked when the USER0 bank is mapped,
 ; and we can assume the stack is valid (because interrupts won't work
 ; otherwise).
@@ -137,7 +140,8 @@ READERE:
 ; Selects a drive, returning the address of the DPH in HL (or 0x0000 on
 ; error).
 SELDSKE:
-    ld a, c
+	ld a, (driveswap)
+	xor c
     ld (BDISK), a
 
     ld hl, drive_a_dph

--- a/arch/nc200/build.lua
+++ b/arch/nc200/build.lua
@@ -151,6 +151,7 @@ diskimage {
         ["bbcbasic.com"] = "third_party/bbcbasic+bbcbasic_ADM3A",
         ["qe.com"] = "cpmtools+qe_NC200",
         ["flash.com"] = "arch/nc200/tools+flash",
+        ["flipdisk.com"] = "arch/nc200/tools+flipdisk",
         ["mkfs.com"] = "cpmtools+mkfs",
         ["rawdisk.com"] = "cpmtools+rawdisk",
 		["z8e.com"] = "third_party/z8e+z8e_NC200",

--- a/arch/nc200/build.lua
+++ b/arch/nc200/build.lua
@@ -2,6 +2,38 @@ include "third_party/ld80/build.lua"
 include "third_party/zmac/build.lua"
 include "utils/build.lua"
 
+--- Memory layout configuration ------------------------------------------
+
+-- Configure the BIOS size here; this will then emit an addresses.lib file
+-- which contains the position of the BDOS and CCP.
+
+local BIOS_SIZE = 0x0300
+local BDOS_SIZE = 3584            -- fixed
+local CCP_SIZE = 2048             -- fixed
+local CPM_SIZE = BIOS_SIZE + BDOS_SIZE + CCP_SIZE
+local BBASE = 0x10000 - BIOS_SIZE
+local FBASE = BBASE - BDOS_SIZE
+local CBASE = FBASE - CCP_SIZE
+
+normalrule {
+        name = "addresses_lib",
+        ins = {},
+        outleaves = { "addresses.lib" },
+        commands = {
+                "echo BIOS_SIZE = "..BIOS_SIZE.." > %{outs[1]}",
+                "echo BDOS_SIZE = "..BDOS_SIZE.." >> %{outs[1]}",
+                "echo CCP_SIZE = "..CCP_SIZE.." >> %{outs[1]}",
+                "echo CPM_SIZE = "..CPM_SIZE.." >> %{outs[1]}",
+                "echo BBASE = "..BBASE.." >> %{outs[1]}",
+                "echo FBASE = "..FBASE.." >> %{outs[1]}",
+                "echo CBASE = "..CBASE.." >> %{outs[1]}",
+        }
+}
+
+--- Bootstrap ------------------------------------------------------------
+
+-- The program the NC200 runs on startup.
+
 zmac {
     name = "auto",
     srcs = { "./auto.z80" },
@@ -17,6 +49,8 @@ objectify {
     srcs = { "+auto" }
 }
 
+--- FAT boot data --------------------------------------------------------
+
 local bootfiles = filenamesof("./boot/*.z80")
 for _, f in pairs(bootfiles) do
     local base = basename(f)
@@ -31,18 +65,26 @@ for _, f in pairs(bootfiles) do
     }
 end
 
+--- BIOS -----------------------------------------------------------------
+
+-- The CP/M BIOS itself.
+
 zmac {
     name = "bios",
     srcs = { "./bios.z80" },
     deps = {
         "include/*.lib",
-        "./include/*.lib"
+        "./include/*.lib",
+		"+addresses_lib",
     },
 }
 
--- Builds the memory image.
+-- Builds the memory image. This is a 64kB file containing the entire CP/M
+-- memory image, including the supervisor at the bottom.
+
 ld80 {
-    name = "bootfile_mem",
+    name = "memory_img",
+	address = 0,
     srcs = {
         "-P0000", "+startup.z80",
         "-P000b", "+bpb1.z80",
@@ -54,20 +96,40 @@ ld80 {
         "-P1000", "+rootdir.z80",
         "arch/nc200/supervisor+supervisor",
         "-P1e00", "+relauto.z80",
-        "-Pe700", "third_party/zcpr1+zcpr",
-        "-Pef00", "third_party/zsdos+zsdos",
-        "-Pfd00", "+bios",
+        "-P"..string.format("%x", CBASE), "third_party/zcpr1+zcpr",
+        "-P"..string.format("%x", FBASE), "third_party/zsdos+zsdos",
+        "-P"..string.format("%x", BBASE), "+bios",
     }
 }
 
--- Repackages the memory image as a boot track.
+-- We now chop it up to remove the supervisor and the CCP/BDOS/BIOS, which go into
+-- the system tracks.
+
+binslice {
+	name = "cpm_img",
+	src = { "+memory_img" },
+	start = CBASE,
+	length = CPM_SIZE
+}
+
+binslice {
+	name = "supervisor_img",
+	src = { "+memory_img" },
+	start = 0,
+	length = 9*1024
+}
+
+-- And combine them into the system track image.
+
 normalrule {
-    name = "bootfile",
-    ins = { "+bootfile_mem" },
-    outleaves = { "bootfile.img" },
+    name = "systemtrack_img",
+    ins = {
+		"+supervisor_img",
+		"+cpm_img",
+	},
+    outleaves = { "systemtrack.img" },
     commands = {
-        "dd if=%{ins[1]} of=%{outs} status=none bs=256 count=36",
-        "dd if=%{ins[1]} of=%{outs} status=none bs=256 seek=36 skip=231 count=25"
+		"cat %{ins} > %{outs[1]}"
     }
 }
 
@@ -79,7 +141,7 @@ unix2cpm {
 diskimage {
     name = "diskimage",
     format = "nc200cpm",
-    bootfile = { "arch/nc200+bootfile" },
+    bootfile = { "arch/nc200+systemtrack_img" },
     map = {
         ["dump.com"] = "cpmtools+dump",
         ["stat.com"] = "cpmtools+stat",

--- a/arch/nc200/include/supervisor.lib
+++ b/arch/nc200/include/supervisor.lib
@@ -9,7 +9,7 @@
 ; We map stuff in as needed.
 
 SUPERVISOR_BANK equ 0x40 ; -> 0x0000
-CACHE1_BANK     equ 0x41
+CPM_BANK        equ 0x41
 CACHE2_BANK     equ 0x42
 CACHE3_BANK     equ 0x43
 USER0_BANK      equ 0x44 ; -> 0x0000

--- a/arch/nc200/supervisor/build.lua
+++ b/arch/nc200/supervisor/build.lua
@@ -29,6 +29,7 @@ zmac {
         "arch/common/utils/deblocker.lib",
         "arch/common/utils/tty.lib",
         "arch/nc200/include/*.lib",
+        "arch/nc200+addresses_lib",
         "./*.inc",
         "+keytab_inc",
         "+font_inc",

--- a/arch/nc200/supervisor/startup.inc
+++ b/arch/nc200/supervisor/startup.inc
@@ -22,7 +22,7 @@ label STARTUP
 
     ld bc, 0                    ; start sector
     ld de, 1                    ; track
-    ld hl, 0x4000               ; start address in userspace
+    ld hl, CBASE                ; start address in userspace
 .1
     ld (current_dma), hl        ; set destination address
     push bc
@@ -44,10 +44,10 @@ label STARTUP
 
 	ld a, CPM_BANK
 	out (PORT_BANK1), a         ; map cache to 0x4000.
-	ld a, USER1_BANK
-	out (PORT_BANK2), a			; map userspace 0x4000 to 0x8000.
+	ld a, USER3_BANK
+	out (PORT_BANK3), a			; map userspace 0xc000 to 0xc000.
 	ld de, 0x4000				; dest
-	ld hl, 0x8000				; src
+	ld hl, CBASE 	 			; src
 	ld bc, CPM_SIZE				; length
 	ldir
 
@@ -72,7 +72,7 @@ warmboot:
 	out (PORT_BANK3), a			; map user space 0xc000 to 0xc00.
 	ld de, CBASE             	; dest
 	ld hl, 0x4000               ; src
-	ld bc, CPM_SIZE             ; length
+	ld bc, BDOS_SIZE+CCP_SIZE   ; length
 	ldir
 
     ; Initialise the page zero CP/M-y things.

--- a/arch/nc200/supervisor/startup.inc
+++ b/arch/nc200/supervisor/startup.inc
@@ -12,7 +12,49 @@ label STARTUP
     ld hl, str.banner
     call tty_puts
     call pcmcia_init
-    ; fall through
+
+	ld hl, str.loading
+	call tty_puts
+
+	; Load the CCP, BDOS and BIOS into userspace.
+
+    call fd765_recalibrate_twice
+
+    ld bc, 0                    ; start sector
+    ld de, 1                    ; track
+    ld hl, 0x4000               ; start address in userspace
+.1
+    ld (current_dma), hl        ; set destination address
+    push bc
+    push de
+    push hl
+    call fd_read128
+    pop hl
+
+    ld de, 128
+    add hl, de                  ; increment destination address
+    pop de
+    pop bc
+    inc bc                      ; next sector
+	ld a, CPM_SIZE / 128        ; read all the sectors?
+	cp c
+	jr nz, .1
+
+	; Copy from userspace to the cache.
+
+	ld a, CPM_BANK
+	out (PORT_BANK1), a         ; map cache to 0x4000.
+	ld a, USER1_BANK
+	out (PORT_BANK2), a			; map userspace 0x4000 to 0x8000.
+	ld de, 0x4000				; dest
+	ld hl, 0x8000				; src
+	ld bc, CPM_SIZE				; length
+	ldir
+
+	ld hl, str.ready
+	call tty_puts
+
+	; fall through
 coldboot:
     ; Initialise CP/M-y things in the base of userspace.
 
@@ -22,38 +64,21 @@ coldboot:
     ld (0x4000 + IOBYTE), a     ; reset iobyte
     ld (0x4000 + CDISK), a      ; reset current disk
 warmboot:
-    ; Reload the CCP, BDOS and BIOS.
+    ; Reload the CCP, BDOS and BIOS from the cache.
 
-    call fd765_recalibrate_twice
-    jr z, bootfailure
-
-    ld bc, 0                    ; start sector
-    ld de, 1                    ; track
-    ld hl, CBASE                ; start address in userspace
-.1
-    ld (current_dma), hl        ; set destination address
-    push bc
-    push de
-    push hl
-    call fd_read128
-    jr z, bootfailure
-    pop hl
-
-    ld de, 128
-    add hl, de                  ; increment destination address
-    pop de
-    pop bc
-    inc bc                      ; next sector
-    ld a, h
-    or l                        ; run off the end of the address space?
-    jr nz, .1               
+	ld a, CPM_BANK
+	out (PORT_BANK1), a			; map cache to 0x4000.
+	ld a, USER3_BANK
+	out (PORT_BANK3), a			; map user space 0xc000 to 0xc00.
+	ld de, CBASE             	; dest
+	ld hl, 0x4000               ; src
+	ld bc, CPM_SIZE             ; length
+	ldir
 
     ; Initialise the page zero CP/M-y things.
 
     ld a, USER0_BANK
     out (PORT_BANK1), a         ; Map user space 0x0000 to 0x4000.
-    ld a, USER3_BANK            ; Map user space 0xc000 to 0xc000.
-    out (PORT_BANK3), a
 
     ld a, 0xc3                  ; JP instruction
 
@@ -84,16 +109,13 @@ warmboot:
 
     jp BOOT
 
-bootfailure:
-    ld hl, str.insert_disk
-    call tty_puts
-    call kbd_get_next_key
-    ld sp, SYSSTK
-    jr warmboot
-    
-str.insert_disk:
-	db "[Cannot load CP/M, please insert a system disk]", 10, 0
-
 str.banner:
     cpmish_banner "Amstrad NC200"
     db 0
+
+str.loading:
+	db "Reading system track", 10, 13, 0
+
+str.ready:
+	db "Ready", 10, 13, 0
+

--- a/arch/nc200/supervisor/supervisor.z80
+++ b/arch/nc200/supervisor/supervisor.z80
@@ -6,9 +6,9 @@
 	maclib cpm
 	maclib nc200
 	maclib cpmish
+	maclib addresses
 
 	extern ATABUF
-	extern BBASE
 	extern BDEBLOCK
 	extern BDISK
 	extern BDMA
@@ -17,7 +17,6 @@
 	extern BSECTOR
 	extern BTRACK
 	extern DRVBDPB
-	extern FBASE
 	extern FDBUF
 	extern FONT
 	extern PBAUD

--- a/arch/nc200/tools/build.lua
+++ b/arch/nc200/tools/build.lua
@@ -7,3 +7,19 @@ ackprogram {
         "./pcmcia-tools.s"
     },
 }
+
+zmac {
+	name = "flipdisk_o",
+	srcs = { "./flipdisk.z80" },
+	deps = { "arch/nc200+addresses_lib" }
+}
+
+ld80 {
+	name = "flipdisk",
+	address = 0x100,
+	srcs = {
+		"-P0100",
+		"+flipdisk_o"
+	}
+}
+

--- a/arch/nc200/tools/flipdisk.z80
+++ b/arch/nc200/tools/flipdisk.z80
@@ -1,0 +1,22 @@
+	maclib addresses
+
+	cseg
+	ld hl, BBASE + 0x33
+	ld a, 1
+	xor (hl)
+	ld (hl), a
+
+	ld de, .str.normal
+	jr z, .1
+	ld de, .str.swapped
+.1
+	ld c, 9
+	call 5
+	rst 0
+
+.str.normal:
+	db "A: is FDD, B: is PCMCIA", 13, 10, '$'
+
+.str.swapped:
+	db "A: is PCMCIA, B: is FDD", 13, 10, '$'
+


### PR DESCRIPTION
This makes a few improvements to the NC200 port:

- CCP and BDOS is cached in RAM, so we don't need to hit the disk on warm starts;
- you can swap A: and B: and runtime, so if you have a PCMCIA flash card you can make that drive A:, which drastically speeds up everything.