### PR TITLE
Make Z8E work on the NC200.

### DIFF
--- a/arch/nc200/README.md
+++ b/arch/nc200/README.md
@@ -33,6 +33,12 @@ What you don't get:
 - sysgen, format etc
 - no bugs
 
+**Important note:** the NC200 runs in `im 1` mode, which means that all
+interrupts go through rst 0x38. Unfortunately this is the default system call
+used by debuggers like DDT and SID, so you'll need to patch them to use a
+different one. The supplied copy of `z8e` has been preconfigured for the NC200
+and will work out of the box.
+
 
 How to use it
 -------------

--- a/third_party/z8e/nc200/config.inc
+++ b/third_party/z8e/nc200/config.inc
@@ -1,6 +1,7 @@
-z180	equ	false
-conterm	equ	adm3a
-auxterm	equ	none
-CPM3	equ	false
-SCRHT   equ 18
+z180	    equ	false
+conterm	    equ	adm3a
+auxterm	    equ	none
+CPM3	    equ	false
+SCRHT       equ 18
+DFLTRSTVEC  equ 30h
 

--- a/third_party/z8e/src/z8e.z80
+++ b/third_party/z8e/src/z8e.z80
@@ -463,7 +463,7 @@ getSCB	equ	49
 
 	export	rstVec
 ;rstVec:
-	defb	38h		;Default (but patchable) breakpoint vector
+	defb	DFLTRSTVEC          ; fault (but patchable) breakpoint vector
 
 	export	coMask
 ;coMask:

--- a/third_party/z8e/wp2450ds/config.inc
+++ b/third_party/z8e/wp2450ds/config.inc
@@ -1,6 +1,7 @@
-z180	equ	true
-conterm	equ	adm3a
-auxterm	equ	none
-CPM3	equ	false
-SCRHT   equ 26
+z180	    equ	true
+conterm	    equ	adm3a
+auxterm	    equ	none
+CPM3	    equ	false
+SCRHT       equ 26
+DFLTRSTVEC  equ 38h
 


### PR DESCRIPTION
rst 0x38 is reserved for interrupts, so it needs to be configured to use rst 0x30.

Fixes: #36 