### PR TITLE
Bugfix for nano-z80

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -37,4 +37,6 @@ jobs:
           wp1.img
           kayproii.img
           nc200.img
+          nano-z80.img
+
       

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,6 +58,7 @@ jobs:
           nc200.img
           wp2450.img
           wp2450ds.img
+          nano-z80.img
         fail-if-no-assets: false
 
     - name: release
@@ -72,6 +73,7 @@ jobs:
           kayproii.img
           nc200.img
           wp2450.img
+          nano-z80.img
         tag_name: dev
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/arch/nano-z80/build.py
+++ b/arch/nano-z80/build.py
@@ -79,6 +79,7 @@ diskimage(
         "colorbg.com": "arch/nano-z80/tools+colorbg",
         "cls.com" : "arch/nano-z80/tools+cls",
         "arrowkey.com" : "arch/nano-z80/tools+arrowkey",
+        "imgview.com" : "arch/nano-z80/tools+imgview",
         },
 )
 

--- a/arch/nano-z80/tools/build.py
+++ b/arch/nano-z80/tools/build.py
@@ -50,3 +50,8 @@ ackprogram(
     name="nanoterm",
     srcs=["./nanoterm.c", "./uart.s"],
 )
+
+ackprogram(
+    name="imgview",
+    srcs=["./imgview.c", "./gfx.s"],
+)

--- a/arch/nano-z80/tools/gfx.s
+++ b/arch/nano-z80/tools/gfx.s
@@ -142,3 +142,36 @@ _set_pal_b:
     out PAL_B
     ret
 
+! Get palette R
+.sect .text
+.define _get_pal_r
+_get_pal_r:
+    mvi a, IO_SELECT_VIDEO
+    out IOBANK
+    in PAL_R
+    mvi d,0
+    mov e,a
+    ret
+
+! Get palette G
+.sect .text
+.define _get_pal_g
+_get_pal_g:
+    mvi a, IO_SELECT_VIDEO
+    out IOBANK
+    in PAL_G
+    mvi d,0
+    mov e,a
+    ret
+
+! Get palette B
+.sect .text
+.define _get_pal_b
+_get_pal_b:
+    mvi a, IO_SELECT_VIDEO
+    out IOBANK
+    in PAL_B
+    mvi d,0
+    mov e,a
+    ret
+

--- a/arch/nano-z80/tools/gfx.s
+++ b/arch/nano-z80/tools/gfx.s
@@ -1,0 +1,144 @@
+.sect .text
+.sect .rom
+.sect .data
+.sect .bss
+
+
+IOBANK              = 0x7f
+IO_SELECT_VIDEO     = 0x04
+VID_MODE            = 0x20
+PIX_Y               = 0x21
+PIX_X               = 0x22
+PIX_DATA            = 0x24
+VID_PAGE            = 0x25
+PAL_COLOR           = 0x26
+PAL_R               = 0x27
+PAL_G               = 0x28
+PAL_B               = 0x29
+
+! Set the video mode
+.sect .text
+.define _set_vid_mode
+_set_vid_mode:
+    pop d
+    pop h
+    push h
+    push d
+    mvi a, IO_SELECT_VIDEO
+    out IOBANK
+    mov a,l
+    out VID_MODE
+    ret
+
+! Set pixel X
+.sect .text
+.define _set_pixel_x
+_set_pixel_x:
+    pop d
+    pop h
+    push h
+    push d
+    mvi a, IO_SELECT_VIDEO
+    out IOBANK
+    mov a,l
+    out PIX_X
+    ret
+
+! Set pixel Y
+.sect .text
+.define _set_pixel_y
+_set_pixel_y:
+    pop d
+    pop h
+    push h
+    push d
+    mvi a, IO_SELECT_VIDEO
+    out IOBANK
+    mov a,l
+    out PIX_Y
+    ret
+
+! Set pixel data
+.sect .text
+.define _set_pixel_data
+_set_pixel_data:
+    pop d
+    pop h
+    push h
+    push d
+    mvi a, IO_SELECT_VIDEO
+    out IOBANK
+    mov a,l
+    out PIX_DATA
+    ret
+
+! Set video page
+.sect .text
+.define _set_vid_page
+_set_vid_page:
+    pop d
+    pop h
+    push h
+    push d
+    mvi a, IO_SELECT_VIDEO
+    out IOBANK
+    mov a,l
+    out VID_PAGE
+    ret
+
+! Set palette color
+.sect .text
+.define _set_pal_color
+_set_pal_color:
+    pop d
+    pop h
+    push h
+    push d
+    mvi a, IO_SELECT_VIDEO
+    out IOBANK
+    mov a,l
+    out PAL_COLOR
+    ret
+
+! Set palette R
+.sect .text
+.define _set_pal_r
+_set_pal_r:
+    pop d
+    pop h
+    push h
+    push d
+    mvi a, IO_SELECT_VIDEO
+    out IOBANK
+    mov a,l
+    out PAL_R
+    ret
+
+! Set palette G
+.sect .text
+.define _set_pal_g
+_set_pal_g:
+    pop d
+    pop h
+    push h
+    push d
+    mvi a, IO_SELECT_VIDEO
+    out IOBANK
+    mov a,l
+    out PAL_G
+    ret
+
+! Set palette B
+.sect .text
+.define _set_pal_b
+_set_pal_b:
+    pop d
+    pop h
+    push h
+    push d
+    mvi a, IO_SELECT_VIDEO
+    out IOBANK
+    mov a,l
+    out PAL_B
+    ret
+

--- a/arch/nano-z80/tools/imgview.c
+++ b/arch/nano-z80/tools/imgview.c
@@ -90,7 +90,7 @@ int main(int argc, const char *argv[]) {
     }
     cpm_conout('.');
 
-    // Load and set image data, 19200 bytes = 150 blocks
+    // Load and set image data
     set_pixel_x(0);
     set_pixel_y(0);
     set_vid_page(0);

--- a/arch/nano-z80/tools/imgview.c
+++ b/arch/nano-z80/tools/imgview.c
@@ -1,0 +1,73 @@
+#include <cpm.h>
+#include <stdio.h>
+
+extern void set_vid_mode(uint8_t mode);
+extern void set_pixel_x(uint8_t x);
+extern void set_pixel_y(uint8_t y);
+extern void set_pixel_data(uint8_t c);
+extern void set_vid_page(uint8_t p);
+extern void set_pal_color(uint8_t c);
+extern void set_pal_r(uint8_t r);
+extern void set_pal_g(uint8_t g);
+extern void set_pal_b(uint8_t b);
+
+static uint8_t buffer[128];
+
+int main(void) {
+    uint8_t i,j, pos;
+    uint8_t color;
+    
+    // Open file
+    cpm_fcb.cr = 0;
+
+    if(cpm_open_file(&cpm_fcb) == 0xff) {
+        printf("imgview <imagefile>\n");
+        return;
+    }
+    
+    // Set graphics mode
+    set_vid_mode(0x01);
+    
+    // Load and set palette, 768 bytes = 6 blocks
+    color = 0;
+    pos = 0;
+    for(i=0; i<6; i++) {
+        cpm_set_dma(&buffer);
+        cpm_read_sequential(&cpm_fcb);
+        
+        for(j=0; j<128; j++) {
+            if(pos == 0) {
+                set_pal_color(color);
+                set_pal_r(buffer[j]);
+                color++;
+                pos++;
+            } else if(pos == 1) {
+                set_pal_g(buffer[j]);
+                pos++;
+            } else if(pos == 2) {
+                set_pal_b(buffer[j]);
+                pos=0;
+            }
+
+        }
+    }
+
+    // Load and set image data, 19200 bytes = 150 blocks
+    set_pixel_x(0);
+    set_pixel_y(0);
+    set_vid_page(0);
+
+    for(i=0; i<150; i++) {
+        cpm_set_dma(&buffer);
+        cpm_read_sequential(&cpm_fcb);
+        for(j=0; j<128; j++) {
+            set_pixel_data(buffer[j]);
+        }
+    }
+
+    // Wait for keypress
+    while(!cpm_const());
+
+    // Return to text mode
+    set_vid_mode(0x00);
+}

--- a/arch/nano-z80/tools/imgview.c
+++ b/arch/nano-z80/tools/imgview.c
@@ -19,10 +19,19 @@ static uint8_t pal[768];
 static uint8_t vid_mode;
 FCB img_fcb;
 
+static void print(const char* s) {
+    for(;;) {
+        uint8_t b = *s++;
+        if(!b) return;
+        cpm_conout(b);
+    }
+}
+
 void print_info(void) {
-    printf("imgview <gfxmode> <imagefile>\n");
-    printf("gfxmode == 0 -> 160x120x8\n");
-    printf("gfxmode == 1 -> 320x200x8\n");
+    print("imgview - Image viewer for the nano-z80. Usage:\r\n");
+    print("imgview <gfxmode> <imagefile>\r\n");
+    print("gfxmode == 0 -> 160x120x8\r\n");
+    print("gfxmode == 1 -> 320x200x8\r\n");
     cpm_exit();
 }
 
@@ -34,27 +43,29 @@ int main(int argc, const char *argv[]) {
     if(argc != 3) print_info();
 
     if(*argv[1]=='0') {
-        vid_mode = 0x01;;
+        // Setup buffer size
+        set_vid_mode(0x00);
+        vid_mode = 0x01;
         blocks = 150;
     } else if(*argv[1]=='1') {
-        vid_mode = 0x02;
+        // Setup buffer size
+        set_vid_mode(0x02);
+        vid_mode = 0x03;
         blocks = 500;
     } else print_info();
     
     cpm_parse_filename(&img_fcb, argv[2]);
     if(cpm_open_file(&img_fcb) == 0xff) print_info();    
 
-    // Set graphics mode
-    set_vid_mode(vid_mode);
-    
+    print("Loading image");
+
     // Load and set palette, 768 bytes = 6 blocks
     color = 0;
     pos = 0;
     n = 0;
     for(i=0; i<6; i++) {
         cpm_set_dma(&buffer);
-        cpm_read_sequential(&img_fcb);
-        
+        cpm_read_sequential(&img_fcb);;
         for(j=0; j<128; j++) {
             if(pos == 0) {
                 set_pal_color(color);
@@ -77,20 +88,29 @@ int main(int argc, const char *argv[]) {
 
         }
     }
+    cpm_conout('.');
 
     // Load and set image data, 19200 bytes = 150 blocks
     set_pixel_x(0);
     set_pixel_y(0);
     set_vid_page(0);
-
+    pos=0;
     for(i=0; i<blocks; i++) {
         cpm_set_dma(&buffer);
         cpm_read_sequential(&img_fcb);
+        pos++;
+        if(pos>9) {
+            cpm_conout('.');
+            pos=0;
+        }
         for(j=0; j<128; j++) {
             set_pixel_data(buffer[j]);
         }
     }
 
+    // Set graphics mode
+    set_vid_mode(vid_mode);
+ 
     // Wait for keypress
     while(!cpm_const());
 
@@ -105,4 +125,5 @@ int main(int argc, const char *argv[]) {
         set_pal_g(pal[n]); n++;
         set_pal_b(pal[n]); n++;
     }
+    print("\r\n");
 }

--- a/arch/nano-z80/tools/imgview.c
+++ b/arch/nano-z80/tools/imgview.c
@@ -10,41 +10,67 @@ extern void set_pal_color(uint8_t c);
 extern void set_pal_r(uint8_t r);
 extern void set_pal_g(uint8_t g);
 extern void set_pal_b(uint8_t b);
+extern uint8_t get_pal_r(void);
+extern uint8_t get_pal_g(void);
+extern uint8_t get_pal_b(void);
 
 static uint8_t buffer[128];
+static uint8_t pal[768];
+static uint8_t vid_mode;
+FCB img_fcb;
 
-int main(void) {
-    uint8_t i,j, pos;
+void print_info(void) {
+    printf("imgview <gfxmode> <imagefile>\n");
+    printf("gfxmode == 0 -> 160x120x8\n");
+    printf("gfxmode == 1 -> 320x200x8\n");
+    cpm_exit();
+}
+
+int main(int argc, const char *argv[]) {
+    uint16_t i, blocks, n;
+    uint8_t j, pos;
     uint8_t color;
     
-    // Open file
-    cpm_fcb.cr = 0;
+    if(argc != 3) print_info();
 
-    if(cpm_open_file(&cpm_fcb) == 0xff) {
-        printf("imgview <imagefile>\n");
-        return;
-    }
+    if(*argv[1]=='0') {
+        vid_mode = 0x01;;
+        blocks = 150;
+    } else if(*argv[1]=='1') {
+        vid_mode = 0x02;
+        blocks = 500;
+    } else print_info();
     
+    cpm_parse_filename(&img_fcb, argv[2]);
+    if(cpm_open_file(&img_fcb) == 0xff) print_info();    
+
     // Set graphics mode
-    set_vid_mode(0x01);
+    set_vid_mode(vid_mode);
     
     // Load and set palette, 768 bytes = 6 blocks
     color = 0;
     pos = 0;
+    n = 0;
     for(i=0; i<6; i++) {
         cpm_set_dma(&buffer);
-        cpm_read_sequential(&cpm_fcb);
+        cpm_read_sequential(&img_fcb);
         
         for(j=0; j<128; j++) {
             if(pos == 0) {
                 set_pal_color(color);
+                pal[n] = get_pal_r();
+                n++;      
                 set_pal_r(buffer[j]);
                 color++;
                 pos++;
             } else if(pos == 1) {
+                pal[n] = get_pal_g();
+                n++;
                 set_pal_g(buffer[j]);
                 pos++;
             } else if(pos == 2) {
+                pal[n] = get_pal_b();
+                n++;
                 set_pal_b(buffer[j]);
                 pos=0;
             }
@@ -57,9 +83,9 @@ int main(void) {
     set_pixel_y(0);
     set_vid_page(0);
 
-    for(i=0; i<150; i++) {
+    for(i=0; i<blocks; i++) {
         cpm_set_dma(&buffer);
-        cpm_read_sequential(&cpm_fcb);
+        cpm_read_sequential(&img_fcb);
         for(j=0; j<128; j++) {
             set_pixel_data(buffer[j]);
         }
@@ -70,4 +96,13 @@ int main(void) {
 
     // Return to text mode
     set_vid_mode(0x00);
+
+    // Restore palette
+    n=0;
+    for(i=0; i<256; i++) {
+        set_pal_color(i);
+        set_pal_r(pal[n]); n++;
+        set_pal_g(pal[n]); n++;
+        set_pal_b(pal[n]); n++;
+    }
 }

--- a/arch/nano-z80/tools/nanoterm.c
+++ b/arch/nano-z80/tools/nanoterm.c
@@ -71,26 +71,6 @@ void printhex8(uint8_t b)
     printhex4(b);
 }
 
-/*uint8_t dummy(uint8_t b) {
-    uint8_t x;
-    x=b;
-    return x;
-}*/
-// Wrapper which is only used since I for the life of me can't figure out
-// the correct calling convention
-/*void uart_putc(uint8_t b) {
-    dummy(b);    
-    uart_putc_raw(b);   
-}
-
-void uart_setbaud(uint8_t b) {
-    if(b>5) b=5;
-    
-    dummy(b);
-    uart_setbaud_raw(b);
-}
-*/
-
 void print_settings(void) {
     printx("Current settings");    
     print("Local echo: ");

--- a/arch/nano-z80/tools/nanoterm.c
+++ b/arch/nano-z80/tools/nanoterm.c
@@ -70,14 +70,15 @@ void printhex8(uint8_t b)
     printhex4(b>>4);
     printhex4(b);
 }
-uint8_t dummy(uint8_t b) {
+
+/*uint8_t dummy(uint8_t b) {
     uint8_t x;
     x=b;
     return x;
-}
+}*/
 // Wrapper which is only used since I for the life of me can't figure out
 // the correct calling convention
-void uart_putc(uint8_t b) {
+/*void uart_putc(uint8_t b) {
     dummy(b);    
     uart_putc_raw(b);   
 }
@@ -88,7 +89,7 @@ void uart_setbaud(uint8_t b) {
     dummy(b);
     uart_setbaud_raw(b);
 }
-
+*/
 
 void print_settings(void) {
     printx("Current settings");    
@@ -144,7 +145,7 @@ void set_baudrate(void) {
         printx("Invalid selection");
         return;        
     }
-    uart_setbaud(b);
+    uart_setbaud_raw(b);
     baudrate = uart_getbaud();
     crlf();
     print_settings();
@@ -199,7 +200,7 @@ static void xmodem_receive(void) {
     outp = NAK;
     // Transmission
     while(1) {
-        uart_putc(outp);
+        uart_putc_raw(outp);
         if(getblockchar(&inp)) {
             if(inp == EOT) {
                 crlf();
@@ -260,20 +261,20 @@ static void xmodem_send_block(uint8_t block_cnt) {
     print(".");
 
     // Send header
-    uart_putc(SOH);
-    uart_putc(block_cnt);
-    uart_putc(block_cnt ^ 0xFF);
+    uart_putc_raw(SOH);
+    uart_putc_raw(block_cnt);
+    uart_putc_raw(block_cnt ^ 0xFF);
 
     checksum = 0;
     // Send data
     for(i=0; i<128; i++) {
         data = xmodem_buffer[i];
         checksum += data;
-        uart_putc(data);
+        uart_putc_raw(data);
     }
 
     // Send checksum
-    uart_putc(checksum);    
+    uart_putc_raw(checksum);    
 }
 
 static void xmodem_send(void) {
@@ -324,7 +325,7 @@ static void xmodem_send(void) {
                 if(nak_cnt == 11) {
                     print("Too many NAKs, aborting");
                     crlf();
-                    uart_putc(CAN);
+                    uart_putc_raw(CAN);
                     cpm_close_file(&xmodem_file);
                     return;
                 }
@@ -337,7 +338,7 @@ static void xmodem_send(void) {
                     crlf();
                     print("Transmission done");
                     crlf();
-                    uart_putc(EOT);
+                    uart_putc_raw(EOT);
                     cpm_close_file(&xmodem_file);
                     return;
                 }
@@ -349,7 +350,7 @@ static void xmodem_send(void) {
         if(cpm_const()) {
             // Cancel due to keypress
             cpm_close_file(&xmodem_file);
-            uart_putc(CAN);
+            uart_putc_raw(CAN);
             return;
         }
     }
@@ -412,7 +413,7 @@ int main(void) {
                         xmodem_receive();
                         break;
                     case LOCAL_CMD:
-                        uart_putc(LOCAL_CMD);
+                        uart_putc_raw(LOCAL_CMD);
                         break;
                     case 'h':
                     case 'H':
@@ -435,7 +436,7 @@ int main(void) {
                     cpm_conout(console_data);
                 }
               
-                uart_putc(console_data);
+                uart_putc_raw(console_data);
             }
         }
         if(uart_rx_avail()) {

--- a/arch/nano-z80/tools/uart.s
+++ b/arch/nano-z80/tools/uart.s
@@ -41,7 +41,7 @@ _uart_putc_raw:
     pop d                       ! pop return address
     pop h                       ! pop character to send
     
-    xthl                        ! L = character to send
+    !xthl                        ! L = character to send
     push h
     push d
     mvi a, IO_SELECT_UART 
@@ -72,7 +72,7 @@ _uart_setbaud_raw:
     pop d                       ! pop return address
     pop h                       ! pop setting
     
-    xthl                        ! L = setting
+    !xthl                        ! L = setting
     push h
     push d
     mvi a, IO_SELECT_UART 

--- a/arch/nano-z80/tty.z80
+++ b/arch/nano-z80/tty.z80
@@ -92,6 +92,7 @@ video_init:
     ld b,37
 video_init_delay:
     in a, (VID_BUSY)
+    or a
     ret z
     djnz video_init_delay
     ret

--- a/arch/nano-z80/tty.z80
+++ b/arch/nano-z80/tty.z80
@@ -84,19 +84,14 @@ tty_clear_to_eos:
     out (VID_CLEAR_TO_EOS), a
     ret ;jp tty_update_cursor
 
-; Add a timeout as just checking the busy flag gets stuck sometimes
-; for unknows reasons
 video_init:
     ld a, IO_SELECT_VID
     out (IO_BANK), a
-    ld b,37
-video_init_delay:
+video_init_wait:
     in a, (VID_BUSY)
     or a
-    ret z
-    djnz video_init_delay
+    jr nz, video_init_wait
     ret
-   
 
 ; vim: ts=4 sw=4 et ft=asm
 

--- a/arch/nano-z80/tty.z80
+++ b/arch/nano-z80/tty.z80
@@ -28,11 +28,19 @@ EMULATE_CLEAR_TO_EOS = 0
     maclib tty
     maclib print
 
-TTYINIT equ tty_init
+;TTYINIT equ tty_init
 TTYPUTC equ tty_putc
 TTYPUT8 equ tty_puthex8
 TTYPUT16 equ tty_puthex16
 TTYPUTSI equ tty_putsi
+
+TTYINIT:
+    ; Disable autoscrolling
+    call video_init
+    ld a,0
+    out (VID_AUTOSCROLL),a
+    call tty_init 
+    ret
 
 tty_rawwrite:
     push af


### PR DESCRIPTION
I found a bug in the RTL which caused problems with reading the TTY busy flag from the hardware, so now when that is fixed I have removed the workaround from the BIOS resulting in a much faster TTY.