### PR TITLE
Updates for the nano-z80

### DIFF
--- a/arch/nano-z80/bios.z80
+++ b/arch/nano-z80/bios.z80
@@ -410,15 +410,9 @@ READE:
     ld hl, (BDMA)
     ld a, (BSDPAGE)
     out (SD_PAGE), a
-    ld c, SD_DATA
-read_copy_loop: 
-    in a, (c)
-    ld (hl), a
-    inc hl
-    inc c
-    ld a, c
-    cp a, 0
-    jr nz, read_copy_loop
+    ld c, SD_DATA_BYTE
+    ld b, 128
+    inir
 
     call sd_init
     ret
@@ -437,14 +431,8 @@ WRITEE:
     ld a, (BSDPAGE)
     out (SD_PAGE), a
     ld c, SD_DATA
-write_copy_loop:
-    ld a, (hl)
-    out (c), a
-    inc hl
-    inc c
-    ld a, c
-    cp a, 0
-    jr nz, write_copy_loop
+    ld b, 128
+    otir
 
     ; Write strobe
     ld a,0

--- a/arch/nano-z80/bios.z80
+++ b/arch/nano-z80/bios.z80
@@ -430,7 +430,7 @@ WRITEE:
     ld hl, (BDMA)
     ld a, (BSDPAGE)
     out (SD_PAGE), a
-    ld c, SD_DATA
+    ld c, SD_DATA_BYTE
     ld b, 128
     otir
 

--- a/arch/nano-z80/build.py
+++ b/arch/nano-z80/build.py
@@ -81,6 +81,7 @@ diskimage(
         "arrowkey.com" : "arch/nano-z80/tools+arrowkey",
         "imgview.com" : "arch/nano-z80/tools+imgview",
         "img320.com" : "arch/nano-z80/tools+img320",
+        "img160.com" : "arch/nano-z80/tools+img160",
         },
 )
 

--- a/arch/nano-z80/build.py
+++ b/arch/nano-z80/build.py
@@ -80,6 +80,7 @@ diskimage(
         "cls.com" : "arch/nano-z80/tools+cls",
         "arrowkey.com" : "arch/nano-z80/tools+arrowkey",
         "imgview.com" : "arch/nano-z80/tools+imgview",
+        "img320.com" : "arch/nano-z80/tools+img320",
         },
 )
 

--- a/arch/nano-z80/include/nano-z80.lib
+++ b/arch/nano-z80/include/nano-z80.lib
@@ -67,6 +67,7 @@ SD_PAGE         equ $07         ; Select data page (0-3)
 SD_STATUS       equ $08         ; SD card status
 SD_TYPE         equ $09         ; SD card type
 SD_DATA         equ $80         ; Start of data page ($80-$FF)
+SD_DATA_BYTE    equ $0a         ; SD byte interface
 
 ; Disk definitions
 DRIVE_A_SIZE = 4*1024             ; kB

--- a/arch/nano-z80/tools/build.py
+++ b/arch/nano-z80/tools/build.py
@@ -55,6 +55,15 @@ zmac(
     ],
 )
 
+zmac(
+    name="img160",
+    relocatable=False,
+    src="./img160.z80",
+    deps=[
+        "arch/nano-z80+addresses",
+    ],
+)
+
 
 ackprogram(
     name="nanoterm",

--- a/arch/nano-z80/tools/build.py
+++ b/arch/nano-z80/tools/build.py
@@ -46,6 +46,16 @@ zmac(
     ],
 )
 
+zmac(
+    name="img320",
+    relocatable=False,
+    src="./img320.z80",
+    deps=[
+        "arch/nano-z80+addresses",
+    ],
+)
+
+
 ackprogram(
     name="nanoterm",
     srcs=["./nanoterm.c", "./uart.s"],

--- a/arch/nano-z80/tools/img160.z80
+++ b/arch/nano-z80/tools/img160.z80
@@ -1,0 +1,166 @@
+	maclib addresses
+
+IOBANK          = 0x7f
+IO_SELECT_VIDEO = 0x04
+VID_MODE        = 0x20
+PIX_Y           = 0x21
+PIX_X           = 0x22
+PIX_DATA        = 0x24
+VID_PAGE        = 0x25
+PAL_COLOR       = 0x26
+PAL_R           = 0x27
+PAL_G           = 0x28
+PAL_B           = 0x29
+
+
+	cseg
+	org 0x100
+
+        ; Get command tail length
+        ld a, (0x80)
+        or a
+        jp z, no_file
+
+open_file:
+        ld de, 0x005c
+        ld c, 15
+        call 0x0005
+        cp 0xff
+        jp z, file_error
+
+        ld a, IO_SELECT_VIDEO
+        out (IOBANK), a
+        ; Set pixel to 0, 0
+        xor a
+        out (PIX_X), a
+        out (PIX_Y), a
+
+        ; Load palette from file and set
+        ld c, 6 ; Blocks to read
+        ld d, 0 ; Color index
+        ld e, 0 ; Position index (0, 1, 2)
+pal_loop_outer:
+        push bc
+        push de
+        ; Read block from file
+        ld de, 0x005c
+        ld c, 20
+        call 0x0005
+        ld hl, 0x0080
+        pop de
+        pop bc
+        ld b, 128
+        ; Select video bank
+        ld a, IO_SELECT_VIDEO
+        out (IOBANK), a
+
+pal_loop_inner:
+        ; Write block to palette registers
+        ld a, e
+        cp 0
+        jr z, pal_pos_0
+        cp 1
+        jr z, pal_pos_1
+        ; Pos 2
+        ld a, (hl)
+        out (PAL_B), a
+        inc hl
+        ld e, 0
+        jr pal_loop_end
+
+pal_pos_0:
+        ld a, d
+        out (PAL_COLOR), a      ; Set color index
+        inc d
+        ld a, (hl)
+        out (PAL_R), a
+        inc hl
+        inc e
+        jr pal_loop_end
+
+pal_pos_1:
+        ld a, (hl)
+        out (PAL_G), a
+        inc hl
+        inc e
+        jr pal_loop_end
+
+pal_loop_end:
+        djnz pal_loop_inner
+
+        dec c
+        ld a, c
+        or a
+        jr nz, pal_loop_outer
+
+        ; Read image data
+        ld bc, 150      ; blocks to read
+
+read_img_loop:
+        push bc
+        ; Read block from file
+        ld de, 0x005c
+        ld c, 20
+        call 0x0005
+        
+        ; Select video bank
+        ld a, IO_SELECT_VIDEO
+        out (IOBANK), a
+
+        ; Write block to graphics memory
+        ld hl, 0x0080 
+        ld b, 128
+        ld c, PIX_DATA
+        otir
+        pop bc
+        dec bc
+        ld a, b
+        or c
+        jr nz, read_img_loop
+
+        ; Change to graphics mode
+        ld a, IO_SELECT_VIDEO
+        out (IOBANK), a
+        ld a, 0x01
+        out (VID_MODE), a
+
+        ; Wait for keypress
+        ld c, 1
+        call 5
+
+        ; Change back to text mode
+        ld a, IO_SELECT_VIDEO
+        out (IOBANK), a
+        ld a, 0x00
+        out (VID_MODE), a
+
+        ; Exit
+        ret
+               
+file_error:
+        call print_string_inline
+        db "Error loading file"
+        db 13, 10
+        db 0
+        ret
+                
+
+no_file:
+        call print_string_inline
+        db "Usage: img160 imagefile"
+        db 13, 10
+        db 0
+        ret
+
+print_string_inline:
+        pop hl
+        ld a,(hl)
+        inc hl
+        push hl
+        cp 0
+        ret z
+        ld c, a
+        call BBASE+0x0c ; CONOUT
+        jr print_string_inline
+
+

--- a/arch/nano-z80/tools/img320.z80
+++ b/arch/nano-z80/tools/img320.z80
@@ -1,0 +1,170 @@
+	maclib addresses
+
+IOBANK          = 0x7f
+IO_SELECT_VIDEO = 0x04
+VID_MODE        = 0x20
+PIX_Y           = 0x21
+PIX_X           = 0x22
+PIX_DATA        = 0x24
+VID_PAGE        = 0x25
+PAL_COLOR       = 0x26
+PAL_R           = 0x27
+PAL_G           = 0x28
+PAL_B           = 0x29
+
+
+	cseg
+	org 0x100
+
+        ; Get command tail length
+        ld a, (0x80)
+        or a
+        jp z, no_file
+
+open_file:
+        ld de, 0x005c
+        ld c, 15
+        call 0x0005
+        cp 0xff
+        jp z, file_error
+
+        ; Set 320x200 buffer
+        ld a, IO_SELECT_VIDEO
+        out (IOBANK), a
+        ld a, 0x02
+        out (VID_MODE), a
+
+        ; Set pixel to 0, 0
+        xor a
+        out (PIX_X), a
+        out (PIX_Y), a
+
+        ; Load palette from file and set
+        ld c, 6 ; Blocks to read
+        ld d, 0 ; Color index
+        ld e, 0 ; Position index (0, 1, 2)
+pal_loop_outer:
+        push bc
+        push de
+        ; Read block from file
+        ld de, 0x005c
+        ld c, 20
+        call 0x0005
+        ld hl, 0x0080
+        pop de
+        pop bc
+        ld b, 128
+        ; Select video bank
+        ld a, IO_SELECT_VIDEO
+        out (IOBANK), a
+
+pal_loop_inner:
+        ; Write block to palette registers
+        ld a, e
+        cp 0
+        jr z, pal_pos_0
+        cp 1
+        jr z, pal_pos_1
+        ; Pos 2
+        ld a, (hl)
+        out (PAL_B), a
+        inc hl
+        ld e, 0
+        jr pal_loop_end
+
+pal_pos_0:
+        ld a, d
+        out (PAL_COLOR), a      ; Set color index
+        inc d
+        ld a, (hl)
+        out (PAL_R), a
+        inc hl
+        inc e
+        jr pal_loop_end
+
+pal_pos_1:
+        ld a, (hl)
+        out (PAL_G), a
+        inc hl
+        inc e
+        jr pal_loop_end
+
+pal_loop_end:
+        djnz pal_loop_inner
+
+        dec c
+        ld a, c
+        or a
+        jr nz, pal_loop_outer
+
+        ; Read image data
+        ld bc, 500      ; blocks to read
+
+read_img_loop:
+        push bc
+        ; Read block from file
+        ld de, 0x005c
+        ld c, 20
+        call 0x0005
+        
+        ; Select video bank
+        ld a, IO_SELECT_VIDEO
+        out (IOBANK), a
+
+        ; Write block to graphics memory
+        ld hl, 0x0080 
+        ld b, 128
+        ld c, PIX_DATA
+        otir
+        pop bc
+        dec bc
+        ld a, b
+        or c
+        jr nz, read_img_loop
+
+        ; Change to graphics mode
+        ld a, IO_SELECT_VIDEO
+        out (IOBANK), a
+        ld a, 0x03
+        out (VID_MODE), a
+
+        ; Wait for keypress
+        ld c, 1
+        call 5
+
+        ; Change back to text mode
+        ld a, IO_SELECT_VIDEO
+        out (IOBANK), a
+        ld a, 0x00
+        out (VID_MODE), a
+
+        ; Exit
+        ret
+               
+file_error:
+        call print_string_inline
+        db "Error loading file"
+        db 13, 10
+        db 0
+        ret
+                
+
+no_file:
+        call print_string_inline
+        db "Usage: img320 imagefile"
+        db 13, 10
+        db 0
+        ret
+
+print_string_inline:
+        pop hl
+        ld a,(hl)
+        inc hl
+        push hl
+        cp 0
+        ret z
+        ld c, a
+        call BBASE+0x0c ; CONOUT
+        jr print_string_inline
+
+

--- a/arch/nano-z80/tools/nanoterm.c
+++ b/arch/nano-z80/tools/nanoterm.c
@@ -187,6 +187,8 @@ static void xmodem_receive(void) {
                 print("Transmission done");
                 crlf();
                 cpm_close_file(&xmodem_file);
+                outp = ACK;
+                uart_putc_raw(outp);
                 return;
             }
             if(inp == CAN) {


### PR DESCRIPTION
A mixed bag of updates for the nano-z80:
* Updates to the SD-card read/write code in the BIOS to match hardware updates, speeds up disk access by using OTIR/INIR
* Bugfix to the xmodem receive code in nanoterm, send a final ACK when the transmission is done
* Added a couple of nano.-z80 specific tools for viewing images written in assembly, which are about ~3 times faster loading the images compared to the tool written in C